### PR TITLE
Further enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,22 +6,26 @@ ARG repo_ref
 USER root
 
 RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install -y --no-install-recommends \
     iperf3 \
     gcc \
     git \
     pulseaudio-utils \
     python3 \
     python3-dev \
-    python3-matplotlib \
     python3-pip \
-    python3-scipy \
     python3-setuptools \
-    python3-wheel \
     python3-wxgtk4.0 \
-    wireless-tools && \
-  pip3 install \
-    iperf3
+    wireless-tools \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install iperf3 matplotlib scipy wheel
+
+# Install libnl from DL6ER's fork because the python3.6+
+# compatibility fixes weren't included in the upstream
+# project in 12/2020
+RUN pip3 install --upgrade --user git+https://github.com/DL6ER/libnl
 
 COPY . /app
 

--- a/README.rst
+++ b/README.rst
@@ -121,14 +121,16 @@ The end result of this process for a given survey (Title) should be some ``.png`
 
 * `channels24_TITLE.png` - Bar graph of average signal quality of APs seen on 2.4 GHz channels, by channel. Useful for visualizing channel contention. (Based on 20 MHz channel bandwidth)
 * `channels5_TITLE.png` - Bar graph of average signal quality of APs seen on 5 GHz channels, by channel. Useful for visualizing channel contention. (Based on per-channel bandwidth from 20 to 160 MHz)
-* `jitter_TITLE.png` - Heatmap based on UDP jitter measurement in milliseconds.
-* `rss_TITLE.png` - Heatmap based on the received signal strength.
+* `signal_quality_TITLE.png` - Heatmap based on the received signal strength.
+* `tx_power_TITLE.png` - Heatmap based on the transmitter power your WiFi card used. If your WiFi card doe snot support adaptive power management, this number will stay constant.
 * `tcp_download_Mbps_TITLE.png` - Heatmap of `iperf3` transfer rate, TCP, downloading from server to client.
 * `tcp_upload_Mbps_TITLE.png` - Heatmap of `iperf3` transfer rate, TCP, uploading from client to server.
+* `udp_download_Mbps_TITLE.png` - Heatmap of `iperf3` transfer rate, UDP, downloading from server to client.
 * `udp_upload_Mbps_TITLE.png` - Heatmap of `iperf3` transfer rate, UDP, uploading from client to server.
+* `jitter_download_TITLE.png` - Heatmap based on UDP jitter measurement in milliseconds.
+* `jitter_upload_TITLE.png` - Heatmap based on UDP jitter measurement in milliseconds.
 * `frequency_TITLE.png` - Heatmap of used frequency. May reveal zones in which Wi-Fi steering moved the device onto a different band (2.4GHz / 5 GHz co-existance).
-* `channel_rx_bitrate_TITLE.png` - Heatmap of advertised channel bandwidth in RX direction (AP to client)
-* `channel_tx_bitrate_TITLE.png` - Heatmap of advertised channel bandwidth in TX direction (client to AP)
+* `channel_bitrate_TITLE.png` - Heatmap of negotiated channel bandwidth
 
 If you'd like to synchronize the colors/thresholds across multiple heatmaps, such as when comparing different AP placements, you can run ``wifi-heatmap-thresholds`` passing it each of the titles / output JSON filenames. This will generate a ``thresholds.json`` file in the current directory, suitable for passing to the ``wifi-heatmap`` ``-t`` / ``--thresholds`` option.
 

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Inside Docker, however, this becomes quite a bit more difficult. Currently Pulse
 Heatmap Generation
 ++++++++++++++++++
 
-Once you've performed a survey with a given title and the results are saved in ``Title.json``, run ``wifi-heatmap PNG Title`` to generate heatmap files in the current directory. This process does not require (and shouldn't have) root/sudo and operates only on the JSON data file. For this, it will look better if you use a PNG without the measurement location marks.
+Once you've performed a survey with a given title and the results are saved in ``Title.json``, run ``wifi-heatmap TITLE`` to generate heatmap files in the current directory. This process does not require (and shouldn't have) root/sudo and operates only on the JSON data file. For this, it will look better if you use a PNG without the measurement location marks.
 
 You can optionally pass the path to a JSON file mapping the access point MAC addresses (BSSIDs) to friendly names via the ``-a`` / ``--ap-names`` argument. If specified, this will annotate each measurement dot on the heatmap with the name (mapping value) and frequency band of the AP that was connected when the measurement was taken. This can be useful in multi-AP roaming environments.
 
@@ -161,7 +161,7 @@ Note that running with ``--net="host"`` and ``--privileged`` is required in orde
 Heatmap
 +++++++
 
-``docker run -it --rm -v $(pwd):/pwd -w /pwd jantman/python-wifi-survey-heatmap:23429a4 wifi-heatmap floorplan.png DeckTest``
+``docker run -it --rm -v $(pwd):/pwd -w /pwd jantman/python-wifi-survey-heatmap:23429a4 wifi-heatmap Example``
 
 iperf3 server
 +++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -68,20 +68,19 @@ Performing a Survey
 
 The survey tool (``wifi-survey``) must be run as root or via ``sudo`` in order to use iwconfig/iwlist.
 
-First connect to the network that you want to survey. Then, run ``sudo wifi-survey INTERFACE PNG Title`` where:
+First connect to the network that you want to survey. Then, run ``sudo wifi-survey`` where:
 
-* ``INTERFACE`` is the name of your Wireless interface (e.g. ``wlp3s0``)
-* ``PNG`` is the path to a floorplan PNG file to use as the background for the map; see `examples/example_floorplan.png <examples/example_floorplan.png>`_ for an example. In order to compare multiple surveys it may be helpful to pre-mark your measurement points on the floorplan, like `examples/example_with_marks.png <examples/example_with_marks.png`_. The UI currently loads the PNG at exact size, so it may help to scale your PNG file to your display.
-* ``Title`` is the title for the survey (such as the network name or AP location), which will also be used to name the data file and output files.
+Command-line options include:
 
-If ``Title.json`` already exists, the data from it will be pre-loaded into the application; this can be used to resume a survey.
-
-Some other command-line options include:
-
-* ``-s`` / ``--server IPERF3_SERVER`` to enable ``iperf3`` scans. The generated speed heatmaps are very useful (much more useful than signal strength) in visualizing the *real* performance of your network as they are live measurements with real data (instead of only theoretical values).
+* ``-i INTERFACE`` / ``--interface INTERFACE`` is the name of your Wireless interface (e.g. ``wlp3s0``)
+* ``-p PICTURE`` / ``--picture PICTURE`` is the path to a floorplan PNG file to use as the background for the map; see `examples/example_floorplan.png <examples/example_floorplan.png>`_ for an example. In order to compare multiple surveys it may be helpful to pre-mark your measurement points on the floorplan, like `examples/example_with_marks.png <examples/example_with_marks.png`_. The UI currently loads the PNG at exact size, so it may help to scale your PNG file to your display.
+* ``-t TITLE`` / ``--title TITLE`` is the title for the survey (such as the network name or AP location), which will also be used to name the data file and output files.
+* ``-s IPERF3_SERVER`` / ``--server IPERF3_SERVER`` to enable ``iperf3`` scans. The generated speed heatmaps are very useful (much more useful than signal strength) in visualizing the *real* performance of your network as they are live measurements with real data (instead of only theoretical values).
 * ``-S`` / ``--scan`` to enable wireless scaning at the end of each measurement. This may take a lot of time, however, generates data used later for generating channel utilization graphs. If you're using a modern wireless product that allows running RF scans, it makes sense to use that data instead of these scans.
-* ``-b`` / ``--bssid BSSID`` allows you to specify a single desired BSSID for your survey. This will be checked several times during of every measurement, and the measurement will be discarded if you're connected to the wrong BSSID. This can be useful as a safeguard to make sure you don't accidentally roam to a different AP.
-* ``-d`` / ``--duration`` allows you to change the duration of each individual `iperf3` test run (default is 10 seconds as mentioned above)
+* ``-b BSSID`` / ``--bssid BSSID`` allows you to specify a single desired BSSID for your survey. This will be checked several times during of every measurement, and the measurement will be discarded if you're connected to the wrong BSSID. This can be useful as a safeguard to make sure you don't accidentally roam to a different AP.
+* ``-d 123`` / ``--duration 123`` allows you to change the duration of each individual `iperf3` test run (default is 10 seconds as mentioned above)
+
+If ``TITLE.json`` already exists, the data from it will be pre-loaded into the application; this can be used to **resume a survey**.
 
 When the UI loads, you should see your PNG file displayed. The UI is really simple:
 
@@ -155,7 +154,7 @@ Survey
      -e DISPLAY=$DISPLAY \
      -v "$HOME/.Xauthority:/root/.Xauthority:ro" \
      jantman/python-wifi-survey-heatmap \
-     wifi-survey INTERFACE FLOORPLAN.png TITLE
+     wifi-survey
 
 Note that running with ``--net="host"`` and ``--privileged`` is required in order to manipulate the host's wireless interface.
 

--- a/wifi_survey_heatmap/collector.py
+++ b/wifi_survey_heatmap/collector.py
@@ -62,11 +62,18 @@ class Collector(object):
     def run_iperf(self, udp=False, reverse=False):
         client = iperf3.Client()
         client.duration = self._duration
-        client.server_hostname = self._iperf_server
-        client.port = 5201
+
+        server_parts = self._iperf_server.split(":")
+        if len(server_parts) == 2:
+            client.server_hostname = server_parts[0]
+            client.port = int(server_parts[1])
+        else:
+            client.server_hostname = self._iperf_server
+            client.port = 5201 # substitute some default port
+
         client.protocol = 'udp' if udp else 'tcp'
         client.reverse = reverse
-        logger.debug(
+        logger.info(
             'Running iperf to %s; udp=%s reverse=%s', self._iperf_server,
             udp, reverse
         )
@@ -74,7 +81,7 @@ class Collector(object):
             res = client.run()
             if res.error is None:
                 break
-            logger.error('iperf error: %s; retrying', res.error)
+            logger.error('iperf error %s; retrying', res.error)
         logger.debug('iperf result: %s', res)
         return res
 

--- a/wifi_survey_heatmap/collector.py
+++ b/wifi_survey_heatmap/collector.py
@@ -47,19 +47,17 @@ logger = logging.getLogger(__name__)
 
 class Collector(object):
 
-    def __init__(self, interface_name, server_addr, duration, scan=True):
+    def __init__(self, server_addr, duration, scanner, scan=True):
         super().__init__()
         logger.debug(
             'Initializing Collector for interface: %s; iperf server: %s',
-            interface_name, server_addr
+            scanner.interface_name, server_addr
         )
         # ensure interface_name is a wireless interfaces
-        self._interface_name = interface_name
         self._iperf_server = server_addr
         self._scan = scan
         self._duration = duration
-
-        self.scanner = Scanner(interface_name, scan)
+        self.scanner = scanner
 
     def run_iperf(self, udp=False, reverse=False):
         client = iperf3.Client()

--- a/wifi_survey_heatmap/heatmap.py
+++ b/wifi_survey_heatmap/heatmap.py
@@ -275,9 +275,13 @@ class HeatMapGenerator(object):
         gx, gy = np.meshgrid(x, y)
         gx, gy = gx.flatten(), gy.flatten()
         for k, ptitle in self.graphs.items():
-            self._plot(
-                a, k, '%s - %s' % (self._title, ptitle), gx, gy, num_x, num_y
-            )
+            try:
+                self._plot(
+                    a, k, '%s - %s' % (self._title, ptitle), gx, gy, num_x, num_y
+                )
+            except:
+                logger.warning('Cannot create {} plot: '
+                               'insufficient data'.format(k))
 
     def _channel_to_signal(self):
         """

--- a/wifi_survey_heatmap/heatmap.py
+++ b/wifi_survey_heatmap/heatmap.py
@@ -239,10 +239,7 @@ class HeatMapGenerator(object):
                 row['result']['ssid'].upper(),
                 row['result']['ssid']
             )
-            if row['result']['frequency'] < 5000:
-                a['ap'].append(ap + '_2.4GHz')
-            else:
-                a['ap'].append(ap + '_5GHz')
+            a['ap'].append(ap + ' ({0:.1f} GHz)'.format(1e-3*int(row['result']['frequency'])))
         return a
 
     def _load_image(self):
@@ -425,15 +422,20 @@ class HeatMapGenerator(object):
             alpha=0.5, zorder=100,
             cmap=self._cmap, vmin=vmin, vmax=vmax
         )
-        if self._contours is not None:
+
+        # Draw contours if requested and meaningful in this plot
+        if self._contours is not None and vmin != vmax:
             CS = ax.contour(z, colors='k', linewidths=1, levels=self._contours,
                             extent=(0, self._image_width, self._image_height, 0),
                             alpha=0.3, zorder=150, origin='upper')
             ax.clabel(CS, inline=1, fontsize=6)
         cbar = fig.colorbar(image)
+
         # Print only one ytick label when there is only one value to be shown
         if vmin == vmax:
             cbar.set_ticks([vmin])
+
+        # Draw floorplan itself to the lowest layer with full opacity
         ax.imshow(self._layout, interpolation='bicubic', zorder=1, alpha=1)
         labelsize = FontManager.get_default_size() * 0.4
         if(self._showpoints):
@@ -442,7 +444,7 @@ class HeatMapGenerator(object):
                 if (a['x'][idx], a['y'][idx]) in self._corners:
                     continue
                 ax.plot(
-                    a['x'][idx], a['y'][idx],
+                    a['x'][idx], a['y'][idx], zorder=200,
                     marker='o', markeredgecolor='black', markeredgewidth=1,
                     markerfacecolor=mapper.to_rgba(a[key][idx]), markersize=6
                 )

--- a/wifi_survey_heatmap/ui.py
+++ b/wifi_survey_heatmap/ui.py
@@ -362,7 +362,7 @@ class FloorplanPanel(wx.Panel):
             return
 
         # Skip iperf test if empty server string was given
-        if len(self.collector._iperf_server) > 0:
+        if self.collector._iperf_server is not None:
             for protoname, udp in {'tcp': False, 'udp': True}.items():
                 for suffix, reverse in {'': False, '-reverse': True}.items():
                     # Update progress mark
@@ -525,9 +525,14 @@ def parse_args(argv):
     p = argparse.ArgumentParser(description='wifi survey data collection UI')
     p.add_argument('-v', '--verbose', dest='verbose', action='count', default=0,
                    help='verbose output. specify twice for debug-level output.')
-    p.add_argument('-S', '--no-scan', dest='scan', action='store_false',
-                   default=True, help='skip access point scan')
-    p.add_argument('-b', '--bssid', dest='bssid', action='store', type=str,
+    p.add_argument('-S', '--scan', dest='scan', action='store_true',
+                   default=False, help='Scan for access points in the vicinity')
+    p.add_argument('-s', '--server', dest='IPERF3_SERVER', action='store', type=str,
+                   default=None, help='iperf3 server IP or hostname')
+    p.add_argument('-d', '--duration', dest='IPERF3_DURATION', action='store',
+                   type=int, default=10,
+                   help='Duration of each individual ipref3 test run')
+    p.add_argument('-b', '--bssid', dest='BSSID', action='store', type=str,
                    default=None, help='Restrict survey to this BSSID')
     p.add_argument('--ding', dest='ding', action='store', type=str,
                    default=None,
@@ -535,11 +540,7 @@ def parse_args(argv):
     p.add_argument('--ding-command', dest='ding_command', action='store',
                    type=str, default='/usr/bin/paplay',
                    help='Path to ding command')
-    p.add_argument('-d', '--duration', dest='duration', action='store',
-                   type=int, default=10,
-                   help='Duration of each individual ipref test run')
     p.add_argument('INTERFACE', type=str, help='Wireless interface name')
-    p.add_argument('SERVER', type=str, help='iperf3 server IP or hostname')
     p.add_argument('IMAGE', type=str, help='Path to background image')
     p.add_argument(
         'TITLE', type=str, help='Title for survey (and data filename)'
@@ -593,8 +594,8 @@ def main():
 
     app = wx.App()
     frm = MainFrame(
-        args.IMAGE, args.INTERFACE, args.SERVER, args.TITLE, args.scan,
-        args.bssid, args.ding, args.ding_command, args.duration, None,
+        args.IMAGE, args.INTERFACE, args.IPERF3_SERVER, args.TITLE, args.scan,
+        args.BSSID, args.ding, args.ding_command, args.IPERF3_DURATION, None,
         title='wifi-survey: %s' % args.TITLE,
     )
     frm.Show()

--- a/wifi_survey_heatmap/ui.py
+++ b/wifi_survey_heatmap/ui.py
@@ -283,7 +283,7 @@ class FloorplanPanel(wx.Panel):
         self._moving_point = point
         self._moving_x = point.x
         self._moving_y = point.y
-        point.draw(wx.ClientDC(self), color='blue')
+        point.draw(wx.ClientDC(self), color='lightblue')
 
     def onLeftUp(self, event):
         x, y = pos = self.get_xy(event)
@@ -294,9 +294,9 @@ class FloorplanPanel(wx.Panel):
         oldy = self._moving_point.y
         self._moving_point.x = x
         self._moving_point.y = y
-        self._moving_point.draw(wx.ClientDC(self), color='red')
+        self._moving_point.draw(wx.ClientDC(self), color='lightblue')
         res = self.YesNo(
-            f'Move point from blue ({oldx}, {oldy}) to red ({x}, {y})?'
+            f'Move point from ({oldx}, {oldy}) to ({x}, {y})?'
         )
         if not res:
             self._moving_point.x = self._moving_x
@@ -315,7 +315,7 @@ class FloorplanPanel(wx.Panel):
         self._moving_point.erase(dc)
         self._moving_point.x = x
         self._moving_point.y = y
-        self._moving_point.draw(dc, color='red')
+        self._moving_point.draw(dc, color='lightblue')
 
     def _check_bssid(self):
         # Return early if BSSID is not to be verified

--- a/wifi_survey_heatmap/ui.py
+++ b/wifi_survey_heatmap/ui.py
@@ -471,7 +471,8 @@ class FloorplanPanel(wx.Panel):
         # else this is an error
         if tmp.error.startswith('unable to connect to server'):
             self.warn(
-                'ERROR: Unable to connect to iperf server. Aborting.'
+                'ERROR: Unable to connect to iperf server at {}. Aborting.'.
+                format(self.collector._iperf_server)
             )
             return None
         if self.YesNo('iperf error: %s. Retry?' % tmp.error):

--- a/wifi_survey_heatmap/ui.py
+++ b/wifi_survey_heatmap/ui.py
@@ -598,7 +598,6 @@ def main():
         title='wifi-survey: %s' % args.TITLE,
     )
     frm.Show()
-    frm.Maximize(True)
     frm.SetStatusText('%s' % frm.pnl.GetSize())
     app.MainLoop()
 


### PR DESCRIPTION
## Contributor License Agreement

By submitting this work for inclusion in wifi-survey-heatmap, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the wifi-survey-heatmap project (the Affero GPL v3,
  or any subsequent version of that license if adopted by wifi-survey-heatmap).
* My contribution may perpetually be included in and distributed with wifi-survey-heatmap; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of wifi-survey-heatmap's license.
* I have the legal power and rights to agree to these terms.


---

This pull requests add the following convenience features.

- Draw a red point if a survey failed. Remove this red point when starting a new survey.
- Change color of moving point from red to lightblue as we're now using red to indicate failure.
- Do not start maximized. This makes sense now that we support image scaling.
- Disable scanning by default as it takes quite some time and does not give all that much information in the end.
- Make `SERVER` an optional property to easily skip `iperf3` tests in case there is no suitable server.
- Add frequency graph and differentiate between upload and download UDP jitter.
- Update `Dockerfile` to use patched version of `libnl`
- Allow starting `wifi-survey` without any mandatory arguments. Missing items will be asked for with pre-filled interactive dialogs:
    ![Screenshot from 2020-12-22 11-26-56](https://user-images.githubusercontent.com/16748619/102878758-05783f00-4449-11eb-8a17-e4e49d67d59b.png)
    ![Screenshot from 2020-12-22 11-27-14](https://user-images.githubusercontent.com/16748619/102878881-3c4e5500-4449-11eb-8c59-ee23006c475b.png)
    ![Screenshot from 2020-12-22 11-27-21](https://user-images.githubusercontent.com/16748619/102878753-04dfa880-4449-11eb-9722-2f8d20b94da4.png)
- Store used image filename in JSON file so `wifi-heatmaps` works with `TITLE` alone. This can still be overwritten when explicitly specifying an image.
- Add optional argument `--contours N` to draw N contours in the image (with inline labels)
    ![channel_bitrate_Example json](https://user-images.githubusercontent.com/16748619/102878965-5be57d80-4449-11eb-855b-80663a6482af.png)
- Ensure survey points are drawn on top of everything else when they are used and that contour lines are omitted for uniform data.
    ![channel_Example json](https://user-images.githubusercontent.com/16748619/102879130-9e0ebf00-4449-11eb-982d-82e25681d31d.png)
- Only try to plot for what we have data in the JSON file
- Allow iperf3 server to be specified as `ip:port`
- Update the `README` to reflect these changes.