### PR TITLE
wifi-heatmap-thresholds: add required HeatMapGenerator.__init__ parameters

### DIFF
--- a/wifi_survey_heatmap/heatmap.py
+++ b/wifi_survey_heatmap/heatmap.py
@@ -145,7 +145,7 @@ class HeatMapGenerator(object):
     }
 
     def __init__(
-        self, image_path, title, showpoints, cname, contours, ignore_ssids=[], aps=None,
+        self, image_path, title, showpoints=False, cname='RdYlBu_r', contours=None, ignore_ssids=[], aps=None,
         thresholds=None
     ):
         self._ap_names = {}


### PR DESCRIPTION
The wifi-heatmap-thresholds script is currently not working due to missing parameters. Since the parameters are irrelevant for the functionality of the script I added the default values.

## Contributor License Agreement

By submitting this work for inclusion in wifi-survey-heatmap, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the wifi-survey-heatmap project (the Affero GPL v3,
  or any subsequent version of that license if adopted by wifi-survey-heatmap).
* My contribution may perpetually be included in and distributed with wifi-survey-heatmap; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of wifi-survey-heatmap's license.
* I have the legal power and rights to agree to these terms.
