### PR TITLE
Handle missing data points

### DIFF
--- a/wifi_survey_heatmap/thresholds.py
+++ b/wifi_survey_heatmap/thresholds.py
@@ -55,10 +55,10 @@ class ThresholdGenerator(object):
         items = [HeatMapGenerator(None, t).load_data() for t in titles]
         for key in HeatMapGenerator.graphs.keys():
             res[key]['min'] = min([
-                min(x[key]) for x in items
+                min(value for value in x[key] if value is not None) for x in items
             ])
             res[key]['max'] = max([
-                max(x[key]) for x in items
+                max(value for value in x[key] if value is not None) for x in items
             ])
         with open('thresholds.json', 'w') as fh:
             fh.write(json.dumps(res))


### PR DESCRIPTION
Handle missing data points when calculating thresholds. These are most likely to occur when attempting to measure UDP upload in areas with weak signal and the user chooses not to retry a failed measurment.

Without this, `wifi-heatmap-thresholds` fails with the following error:
```
Traceback (most recent call last):                                                                                                                                                                                                              
  File "/usr/local/bin/wifi-heatmap-thresholds", line 11, in <module>                                                                                                                                                                                                                                                          
    load_entry_point('wifi-survey-heatmap', 'console_scripts', 'wifi-heatmap-thresholds')()                                                                                                                                                                                                                                    
  File "/app/wifi_survey_heatmap/thresholds.py", line 127, in main                                                                                                                                                                                                                                                             
    ThresholdGenerator().generate(args.TITLE)                                                                                                                                                                                                                                               
  File "/app/wifi_survey_heatmap/thresholds.py", line 59, in generate                                                                                                                                                                                                                                                          
    min(x[key]) for x in items                                                                                                                                                                                                  
  File "/app/wifi_survey_heatmap/thresholds.py", line 59, in <listcomp>                                                                                                                                                                                                                                                        
    min(x[key]) for x in items                                                                                                                                                                                                  
TypeError: '<' not supported between instances of 'NoneType' and 'float'                                                                                                                                                                                                                                                       
```

## Contributor License Agreement

By submitting this work for inclusion in wifi-survey-heatmap, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the wifi-survey-heatmap project (the Affero GPL v3,
  or any subsequent version of that license if adopted by wifi-survey-heatmap).
* My contribution may perpetually be included in and distributed with wifi-survey-heatmap; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of wifi-survey-heatmap's license.
* I have the legal power and rights to agree to these terms.
