### PR TITLE
Fixes sudo, UI, duplicate point plotting issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Ideally, you should be running the same exact iperf3 version on both machines.
 Performing a Survey
 +++++++++++++++++++
 
-The survey tool (``wifi-survey``) must be run as root or via ``sudo`` in order to use iwconfig/iwlist (or via Docker; see below).
+The survey tool (``wifi-survey``) only requires root privileges for scans. It can be run via ``sudo`` in which case it will drop back to your user after forking off the scan process, or it will launch the scan process via ``pkexec`` if not started with ``sudo`` (or via Docker; see below).
 
 First connect to the network that you want to survey. Then, run ``sudo wifi-survey`` where:
 
@@ -110,7 +110,7 @@ Playing A Sound When Measurement Finishes
 
 It's possible to have ``wifi-survey`` play a sound when each measurement is complete. This can be handy if you're reading or watching something in another window while waiting for the measurements.
 
-To enable this, call ``wifi-survey`` with the ``--ding`` argument, passing it the path to an audio file to play. A short sound effect is included in this repository at ``wifi_survey_heatmap/complete.oga`` and can be used via ``--ding wifi_survey_heatmap/complete.oga``. by default, this will call ``/usr/bin/paplay`` (the PulseAudio player) passing it the ding file path as the only argument. The command used can be overridden with ``--ding-command /path/to/command`` but it must be one that accepts the path to an audio file as its only argument.
+To enable this, call ``wifi-survey`` with the ``--ding`` argument, passing it the path to an audio file to play. A short sound effect is included in this repository at ``wifi_survey_heatmap/complete.oga`` and can be used via ``--ding wifi_survey_heatmap/complete.oga``. by default, this will call ``/usr/bin/paplay`` (the PulseAudio player) passing it the ding file path as the only argument. The command used can be overridden with ``--ding-command /path/to/command`` but it must be one that accepts the path to an audio file as its only argument. If you launch the scan as your user or via ``sudo``, the UI & the PulseAudio client will be run as your user and work without further configuration. If you run as root not via ``sudo``, then additional PuseAudo configuration may be necessary.
 
 Inside Docker, however, this becomes quite a bit more difficult. Currently PulseAudio systems are supported, and this can be set up and enabled with the following steps:
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ requires = [
     'matplotlib==3.5.2',
     'scipy==1.8.1',
     'libnl3==0.3.0',
+    'pypubsub==4.0.3',
 ]
 
 classifiers = [

--- a/wifi_survey_heatmap/ui.py
+++ b/wifi_survey_heatmap/ui.py
@@ -809,8 +809,7 @@ def main():
     app = wx.App()
 
     if args.scan and p is None:
-        # FIXME: this doesn't work in all environments, we need to munge the env first
-        p = Popen(['pkexec', sys.executable, sys.argv[0], SECRET_ELEVATED_CHILD], stdout=PIPE, stdin=PIPE, text=True)
+        p = Popen(['pkexec', 'env', 'HOME='+os.getenv("HOME"), sys.executable, sys.argv[0], SECRET_ELEVATED_CHILD], stdout=PIPE, stdin=PIPE, text=True)
 
     scanner = Scanner(scan=args.scan)
 


### PR DESCRIPTION
__IMPORTANT:__ Please take note of the below checklist, especially the first two items.

# Pull Request Checklist

- [x] All pull requests must include the Contributor License Agreement (see below).
- [ ] Code should conform to the following:
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [ ] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, feel free to ask for help or submit the PR without tests.
    - [ ] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [ ] documentation has been rebuilt with ``tox -e docs``
    - [ ] All modules should have (and use) module-level loggers.
    - [ ] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [ ] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in wifi-survey-heatmap, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the wifi-survey-heatmap project (the Affero GPL v3,
  or any subsequent version of that license if adopted by wifi-survey-heatmap).
* My contribution may perpetually be included in and distributed with wifi-survey-heatmap; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of wifi-survey-heatmap's license.
* I have the legal power and rights to agree to these terms.


# UI & Sudo & Duplicate Point fixes
I think the UI repainting is fully fixed here. I'm not confident of sudo/paplay yet.

## UI + Scan background thread
The scan method now launches a background thread, if not already launched, to do the work of scanning. This makes the UI interactive and keeps desktop environments happy. I had to setup a pubsub thread callback mechanism as the scan background thread wants to repaint and update the status.

## Sudo + paplay ding
This works, in some environments. I need to fix the other environments and/or document. Feedback appreciated. The UI drops permissions ASAP once it launches the scan subprocess. Communication is via JSON and a Scanner proxy object. Also a security win.

## Plotting duplicate points
Duplicate points cause fun patterns, but useless output. Now they are filtered out

